### PR TITLE
Demo of typical changes to experiment template when making a specific experiment

### DIFF
--- a/crcsim/experiment/README.md
+++ b/crcsim/experiment/README.md
@@ -1,17 +1,15 @@
-# Experiment Template
+# Replication of the CRCCP intervention scenarios
 
-On the `experiment` branch, the files in `crcsim/experiment` provide a template for the experiment structure. New experiments can branch off this branch as a starting point.
+This experiment is a replication of the CRCCP compliance intervention experiment, which was conducted prior to open-sourcing the model and making some changes to the AWS infrastructure. We are replicating this experiment to ensure continuity after those changes.
 
+The CRCCP compliance intervention experiment examines the cost-effectiveness of interventions designed to improve compliance with routine screening.
+
+The experiment is designed around 8 health centers (labeled FHQC1-FHQC8), each having its own baseline compliance rate, intervention cost, and post-intervention compliance rate.
+
+We don't model the intervention explicitly. In other words, we didn't add any code to the model to implement the intervention. Instead, we model the intervention by assuming it leads to a change in the compliance rate, and so we run a pair of simulations: one using the baseline compliance rate and another using the post-intervention compliance rate. Any differences in outcomes can therefore be attributed to the intervention.
 ## Scenarios
 
-Experiments are structured as a set of scenarios. Each scenario is defined by a set of parameters. The scenarios that make up an experiment (and the parameters that define them) are determined by the hypothesis that the experiment intends to test.
-
-This experiment template includes three scenarios:
-1. No screening
-2. 100% screening using colonoscopy
-3. 100% screening using FIT
-
-More complex production experiments might vary screening rates, compliance rates, costs, and other parameters.
+Includes 2 scenarios per health center: one baseline scenario and one intervention scenario. The baseline scenarios are based on real data and the intervention scenarios include a hypothetical increase in screening compliance rates.
 
 The scenarios are created by `prepare.py`. This script reads a set of base parameters defined in `crcsim/experiment/parameters.json`, modifies them to create the scenarios, and saves them in a directory structure that will eventually be copied to AWS.
 
@@ -55,7 +53,7 @@ The subdirectories and files in `scenarios/` must be uploaded to AWS S3 for the 
 
 To upload the files to S3, run
 ```
-aws s3 cp ./scenarios s3://crcsim-exp-template/scenarios --recursive
+aws s3 cp ./scenarios s3://crcsim-exp-crccp-replication/scenarios --recursive
 ```
 *(Another note: this manual step is necessary because `boto3` does not include functionality to upload a directory to S3 recursively. Future experiments could improve this workflow by writing a function to upload the directory recursively in `prepare.py`. Or submit a patch to resolve https://github.com/boto/boto3/issues/358)*
 

--- a/crcsim/experiment/requirements.in
+++ b/crcsim/experiment/requirements.in
@@ -1,5 +1,5 @@
 # Clone the specific commit of the model that you want to use for the experiment
-git+https://github.com/RTIInternational/crcsim.git@10211220d1f38239ac5ec885d00ca7a515449399
+git+https://github.com/RTIInternational/crcsim.git@55312a08eb176556555ce5ecb99ba9628d0afc3e
 
 fire
 pandas==2.1.1

--- a/crcsim/experiment/requirements.txt
+++ b/crcsim/experiment/requirements.txt
@@ -36,7 +36,7 @@ colorama==0.4.4
     # via awscli
 contourpy==1.1.1
     # via matplotlib
-crcsim @ git+https://github.com/RTIInternational/crcsim.git@10211220d1f38239ac5ec885d00ca7a515449399
+crcsim @ git+https://github.com/RTIInternational/crcsim.git@55312a08eb176556555ce5ecb99ba9628d0afc3e
     # via -r requirements.in
 cycler==0.12.0
     # via matplotlib

--- a/crcsim/experiment/run_iteration.sh
+++ b/crcsim/experiment/run_iteration.sh
@@ -12,7 +12,7 @@ if [ ! -d "$output_dir" ]; then
   mkdir $output_dir
 fi
 
-aws s3 cp "s3://crcsim-exp-template/scenarios/$scenario/params.json" "./params.json" 
+aws s3 cp "s3://crcsim-exp-crccp-replication/scenarios/$scenario/params.json" "./params.json" 
 
 crc-simulate \
     --npeople=$npeople \
@@ -23,5 +23,5 @@ crc-simulate \
 crc-analyze \
     --params-file=./params.json &&
 
-aws s3 cp ./results.csv "s3://crcsim-exp-template/scenarios/$scenario/results_$iteration.csv"
-aws s3 cp ./output.csv "s3://crcsim-exp-template/scenarios/$scenario/output_$iteration.csv"
+aws s3 cp ./results.csv "s3://crcsim-exp-crccp-replication/scenarios/$scenario/results_$iteration.csv"
+aws s3 cp ./output.csv "s3://crcsim-exp-crccp-replication/scenarios/$scenario/output_$iteration.csv"

--- a/crcsim/experiment/summarize.py
+++ b/crcsim/experiment/summarize.py
@@ -5,7 +5,7 @@ import pandas as pd
 import s3fs  # noqa: F401
 
 
-S3_BUCKET_NAME = "crcsim-exp-template"
+S3_BUCKET_NAME = "crcsim-exp-crccp-replication"
 
 
 def main() -> None:


### PR DESCRIPTION
Not planning to merge. This draft PR exists to demonstrate the typical changes that we make to the `experiment` template branch when making a new branch for a specific experiment. 

- Make a new branch with the `exp_` prefix. Depending on the experiment, this could branch off the `experiment` template branch or a prior specific experiment branch if that's easier. For example, if we make a bunch of changes for the `exp-complex-experiment` branch, and then want to run a second batch for that experiment with a few small tweaks, it makes more sense to branch `exp-complex-experiment-batch-2` from `exp-complex-experiment`. 
- Change the S3 bucket name in `run_iteration.sh` and `summarize.py` 
- Change `prepare.py` to create the scenarios you need for this experiment. This is typically the most complex and thought-intensive step in defining a new experiment. All the other steps are just logistics; this is where we have to think through how to define the scenarios for the experiment.
- Update the README to reflect these changes. 

Then follow the steps in the README to run the experiment. 