### PR TITLE
Add test switching functionality

### DIFF
--- a/crcsim/agent.py
+++ b/crcsim/agent.py
@@ -1601,8 +1601,8 @@ class Person:
             # their lifetime. In this case, we assign the routine test for each year
             # rather than choosing a single routine test at initiatilization.
             #
-            # Note that indexing self.params["routine_testing_year"] will always
-            # return the min/max testing year, because crcsim.parameters raises an
+            # Indices 0 and -1 of self.params["routine_testing_year"] safely return
+            # the min and max testing years, because crcsim.parameters raises an
             # error if this parameter is not sorted in increasing order.
             if (
                 self.scheduler.time >= self.params["routine_testing_year"][0]

--- a/crcsim/agent.py
+++ b/crcsim/agent.py
@@ -872,6 +872,23 @@ class Person:
         self.diagnostic_test = self.params["diagnostic_test"]
         self.surveillance_test = self.params["surveillance_test"]
 
+        if self.params["use_variable_routine_test"]:
+            # If the simulation is using variable routine tests, then we do not pick
+            # a single routine test for each person. Instead, we will refer to the
+            # routine_testing_year and routine_test_by_year parameters to determine
+            # which test to use each year. This allows a person to switch tests during
+            # their lifetime. We still assign the routine_test attribute here to
+            # avoid errors from yearly actions that expect a person to have a routine
+            # test attribute.
+            starting_test = self.params["routine_test_by_year"][0]
+            self.routine_test = starting_test
+            self.out.add_routine_test_chosen(
+                person_id=self.id,
+                test_name=starting_test,
+                time=self.scheduler.time,
+            )
+            return
+
         # Choose the routine test based on proportions specified in
         # parameters file.
         #
@@ -903,6 +920,7 @@ class Person:
                 self.out.add_routine_test_chosen(
                     person_id=self.id,
                     test_name=test,
+                    time=self.scheduler.time,
                 )
                 break
 
@@ -1245,15 +1263,15 @@ class Person:
 
                 # Store number of polyps found by size. These counts influence how
                 # soon the person needs to be retested.
-                self.previous_test_small[
-                    self.diagnostic_test
-                ] = num_detected_polyps_small
-                self.previous_test_medium[
-                    self.diagnostic_test
-                ] = num_detected_polyps_medium
-                self.previous_test_large[
-                    self.diagnostic_test
-                ] = num_detected_polyps_large
+                self.previous_test_small[self.diagnostic_test] = (
+                    num_detected_polyps_small
+                )
+                self.previous_test_medium[self.diagnostic_test] = (
+                    num_detected_polyps_medium
+                )
+                self.previous_test_large[self.diagnostic_test] = (
+                    num_detected_polyps_large
+                )
 
                 # check whether test resulted in perforation
                 if self.rng.random() < test_params["proportion_perforation"]:
@@ -1519,15 +1537,15 @@ class Person:
 
                 # Store number of polyps found by size. These counts influence how
                 # soon the person needs to be retested.
-                self.previous_test_small[
-                    self.surveillance_test
-                ] = num_detected_polyps_small
-                self.previous_test_medium[
-                    self.surveillance_test
-                ] = num_detected_polyps_medium
-                self.previous_test_large[
-                    self.surveillance_test
-                ] = num_detected_polyps_large
+                self.previous_test_small[self.surveillance_test] = (
+                    num_detected_polyps_small
+                )
+                self.previous_test_medium[self.surveillance_test] = (
+                    num_detected_polyps_medium
+                )
+                self.previous_test_large[self.surveillance_test] = (
+                    num_detected_polyps_large
+                )
 
                 # check whether test resulted in perforation
                 if self.rng.random() < test_params["proportion_perforation"]:
@@ -1576,6 +1594,29 @@ class Person:
             )
 
     def handle_yearly_actions(self, message="Conduct yearly actions"):
+        if self.params["use_variable_routine_test"]:
+            # If the simulation is using variable routine tests, then the parameters
+            # specify a single routine test that every person in the simulation will
+            # use for each testing year. This allows a person to switch tests during
+            # their lifetime. In this case, we assign the routine test for each year
+            # rather than choosing a single routine test at initiatilization.
+            #
+            # Note that indexing self.params["routine_testing_year"] will always
+            # return the min/max testing year, because crcsim.parameters raises an
+            # error if this parameter is not sorted in increasing order.
+            if (
+                self.scheduler.time >= self.params["routine_testing_year"][0]
+                and self.scheduler.time <= self.params["routine_testing_year"][-1]
+            ):
+                self.routine_test = self.params["variable_routine_test"](
+                    self.scheduler.time
+                )
+                self.out.add_routine_test_chosen(
+                    person_id=self.id,
+                    test_name=self.routine_test,
+                    time=self.scheduler.time,
+                )
+
         self.do_tests()
 
         self.scheduler.add_event(

--- a/crcsim/agent.py
+++ b/crcsim/agent.py
@@ -1263,15 +1263,15 @@ class Person:
 
                 # Store number of polyps found by size. These counts influence how
                 # soon the person needs to be retested.
-                self.previous_test_small[self.diagnostic_test] = (
-                    num_detected_polyps_small
-                )
-                self.previous_test_medium[self.diagnostic_test] = (
-                    num_detected_polyps_medium
-                )
-                self.previous_test_large[self.diagnostic_test] = (
-                    num_detected_polyps_large
-                )
+                self.previous_test_small[
+                    self.diagnostic_test
+                ] = num_detected_polyps_small
+                self.previous_test_medium[
+                    self.diagnostic_test
+                ] = num_detected_polyps_medium
+                self.previous_test_large[
+                    self.diagnostic_test
+                ] = num_detected_polyps_large
 
                 # check whether test resulted in perforation
                 if self.rng.random() < test_params["proportion_perforation"]:
@@ -1537,15 +1537,15 @@ class Person:
 
                 # Store number of polyps found by size. These counts influence how
                 # soon the person needs to be retested.
-                self.previous_test_small[self.surveillance_test] = (
-                    num_detected_polyps_small
-                )
-                self.previous_test_medium[self.surveillance_test] = (
-                    num_detected_polyps_medium
-                )
-                self.previous_test_large[self.surveillance_test] = (
-                    num_detected_polyps_large
-                )
+                self.previous_test_small[
+                    self.surveillance_test
+                ] = num_detected_polyps_small
+                self.previous_test_medium[
+                    self.surveillance_test
+                ] = num_detected_polyps_medium
+                self.previous_test_large[
+                    self.surveillance_test
+                ] = num_detected_polyps_large
 
                 # check whether test resulted in perforation
                 if self.rng.random() < test_params["proportion_perforation"]:

--- a/crcsim/analysis.py
+++ b/crcsim/analysis.py
@@ -77,9 +77,9 @@ class Analysis:
         ]
         unscreened_undiagnosed_40yos = unscreened_undiagnosed_40yo_deaths.person_id
         n_unscreened_undiagnosed_40yos = len(unscreened_undiagnosed_40yos)
-        replication_output_row[
-            "n_unscreened_undiagnosed_40yos"
-        ] = n_unscreened_undiagnosed_40yos
+        replication_output_row["n_unscreened_undiagnosed_40yos"] = (
+            n_unscreened_undiagnosed_40yos
+        )
         thousands_of_40yos = n_unscreened_undiagnosed_40yos / 1_000
 
         # Number of times an individual entered the polyp state
@@ -161,9 +161,9 @@ class Analysis:
         discounted_expected_lifespans_over_40 = self.discount_ages(
             expected_lifespans_over_40.time
         )
-        replication_output_row[
-            "discounted_lifeexp_if_unscreened_undiagnosed_at_40"
-        ] = np.mean(discounted_expected_lifespans_over_40)
+        replication_output_row["discounted_lifeexp_if_unscreened_undiagnosed_at_40"] = (
+            np.mean(discounted_expected_lifespans_over_40)
+        )
 
         # Mean observed lifespan among all individuals
         replication_output_row["lifeobs"] = np.mean(deaths.time)
@@ -179,9 +179,9 @@ class Analysis:
         discounted_lifespans_over_40 = self.discount_ages(
             unscreened_undiagnosed_40yo_deaths.time
         )
-        replication_output_row[
-            "discounted_lifeobs_if_unscreened_undiagnosed_at_40"
-        ] = np.mean(discounted_lifespans_over_40)
+        replication_output_row["discounted_lifeobs_if_unscreened_undiagnosed_at_40"] = (
+            np.mean(discounted_lifespans_over_40)
+        )
 
         # Mean number of life years lost to CRC among all individuals
         replication_output_row["lifelost"] = (
@@ -381,12 +381,12 @@ class Analysis:
             mean_discounted_cost_treatment = (
                 treatments_in_phase.discounted_cost.sum() / n_individuals
             )
-            replication_output_row[
-                f"cost_treatment_{phase.lower()}"
-            ] = mean_cost_treatment
-            replication_output_row[
-                f"discounted_cost_treatment_{phase.lower()}"
-            ] = mean_discounted_cost_treatment
+            replication_output_row[f"cost_treatment_{phase.lower()}"] = (
+                mean_cost_treatment
+            )
+            replication_output_row[f"discounted_cost_treatment_{phase.lower()}"] = (
+                mean_discounted_cost_treatment
+            )
             # per 1k undiagnosed and unscreened 40-year-olds
             treatments_in_phase_over_40 = treatments_over_40[
                 treatments_over_40.role.eq(phase)
@@ -423,11 +423,24 @@ class Analysis:
 
         # Number of times each test was adopted for routine screening
         routine_tests_chosen = self.raw_output[
-            self.raw_output.record_type.eq("test_chosen")
+            self.raw_output.record_type.eq("test_chosen") & self.raw_output.time.eq(0)
         ]
         for rt in self.params["routine_tests"]:
             rt_chosen = routine_tests_chosen[routine_tests_chosen.test_name.eq(rt)]
             replication_output_row[f"{rt}_adopted"] = len(rt_chosen.index)
+
+        # Number of years each routine test was used
+        # (if test variable routine test was enabled in the simulation)
+        if self.params["use_variable_routine_test"]:
+            rt_years = self.raw_output[
+                self.raw_output.record_type.eq("test_chosen")
+                & self.raw_output.time.gt(0)
+            ]
+            rt_years_grouped = rt_years.groupby(["test_name"]).agg(
+                count=("time", "count")
+            )
+            for ix, row in rt_years_grouped.iterrows():
+                replication_output_row[f"{ix}_available_as_routine"] = row["count"]
 
         # Number of times each test was performed for routine screening
         # and number of times per thousand unscreened and undiagnosed 40-year-olds
@@ -655,9 +668,9 @@ class Analysis:
         polyp_to_pre["time_polyp_to_pre"] = (
             polyp_to_pre["time_cancer"] - polyp_to_pre["time_polyp_formation"]
         )
-        replication_output_row[
-            "time_polyp_to_pre"
-        ] = polyp_to_pre.time_polyp_to_pre.mean()
+        replication_output_row["time_polyp_to_pre"] = (
+            polyp_to_pre.time_polyp_to_pre.mean()
+        )
 
         # Among all instances of an individual being clinically diagnosed with CRC,
         # mean time between the onset of CRC and the diagnosis of CRC.
@@ -703,9 +716,9 @@ class Analysis:
         clin_to_dead["time_clin_to_dead"] = (
             clin_to_dead["time_dead"] - clin_to_dead["time_clin"]
         )
-        replication_output_row[
-            "time_clin_to_dead"
-        ] = clin_to_dead.time_clin_to_dead.mean()
+        replication_output_row["time_clin_to_dead"] = (
+            clin_to_dead.time_clin_to_dead.mean()
+        )
 
         # Calculate population rates
         status_arrays = self.compute_status_arrays()

--- a/crcsim/analysis.py
+++ b/crcsim/analysis.py
@@ -77,9 +77,9 @@ class Analysis:
         ]
         unscreened_undiagnosed_40yos = unscreened_undiagnosed_40yo_deaths.person_id
         n_unscreened_undiagnosed_40yos = len(unscreened_undiagnosed_40yos)
-        replication_output_row["n_unscreened_undiagnosed_40yos"] = (
-            n_unscreened_undiagnosed_40yos
-        )
+        replication_output_row[
+            "n_unscreened_undiagnosed_40yos"
+        ] = n_unscreened_undiagnosed_40yos
         thousands_of_40yos = n_unscreened_undiagnosed_40yos / 1_000
 
         # Number of times an individual entered the polyp state
@@ -161,9 +161,9 @@ class Analysis:
         discounted_expected_lifespans_over_40 = self.discount_ages(
             expected_lifespans_over_40.time
         )
-        replication_output_row["discounted_lifeexp_if_unscreened_undiagnosed_at_40"] = (
-            np.mean(discounted_expected_lifespans_over_40)
-        )
+        replication_output_row[
+            "discounted_lifeexp_if_unscreened_undiagnosed_at_40"
+        ] = np.mean(discounted_expected_lifespans_over_40)
 
         # Mean observed lifespan among all individuals
         replication_output_row["lifeobs"] = np.mean(deaths.time)
@@ -179,9 +179,9 @@ class Analysis:
         discounted_lifespans_over_40 = self.discount_ages(
             unscreened_undiagnosed_40yo_deaths.time
         )
-        replication_output_row["discounted_lifeobs_if_unscreened_undiagnosed_at_40"] = (
-            np.mean(discounted_lifespans_over_40)
-        )
+        replication_output_row[
+            "discounted_lifeobs_if_unscreened_undiagnosed_at_40"
+        ] = np.mean(discounted_lifespans_over_40)
 
         # Mean number of life years lost to CRC among all individuals
         replication_output_row["lifelost"] = (
@@ -381,12 +381,12 @@ class Analysis:
             mean_discounted_cost_treatment = (
                 treatments_in_phase.discounted_cost.sum() / n_individuals
             )
-            replication_output_row[f"cost_treatment_{phase.lower()}"] = (
-                mean_cost_treatment
-            )
-            replication_output_row[f"discounted_cost_treatment_{phase.lower()}"] = (
-                mean_discounted_cost_treatment
-            )
+            replication_output_row[
+                f"cost_treatment_{phase.lower()}"
+            ] = mean_cost_treatment
+            replication_output_row[
+                f"discounted_cost_treatment_{phase.lower()}"
+            ] = mean_discounted_cost_treatment
             # per 1k undiagnosed and unscreened 40-year-olds
             treatments_in_phase_over_40 = treatments_over_40[
                 treatments_over_40.role.eq(phase)
@@ -668,9 +668,9 @@ class Analysis:
         polyp_to_pre["time_polyp_to_pre"] = (
             polyp_to_pre["time_cancer"] - polyp_to_pre["time_polyp_formation"]
         )
-        replication_output_row["time_polyp_to_pre"] = (
-            polyp_to_pre.time_polyp_to_pre.mean()
-        )
+        replication_output_row[
+            "time_polyp_to_pre"
+        ] = polyp_to_pre.time_polyp_to_pre.mean()
 
         # Among all instances of an individual being clinically diagnosed with CRC,
         # mean time between the onset of CRC and the diagnosis of CRC.
@@ -716,9 +716,9 @@ class Analysis:
         clin_to_dead["time_clin_to_dead"] = (
             clin_to_dead["time_dead"] - clin_to_dead["time_clin"]
         )
-        replication_output_row["time_clin_to_dead"] = (
-            clin_to_dead.time_clin_to_dead.mean()
-        )
+        replication_output_row[
+            "time_clin_to_dead"
+        ] = clin_to_dead.time_clin_to_dead.mean()
 
         # Calculate population rates
         status_arrays = self.compute_status_arrays()
@@ -983,11 +983,11 @@ class Analysis:
         """
         # Sum all of the person status arrays to get an array of counts of the number of
         # people in each status for each year.
-        statuses: np.ndarray = sum(status_arrays)
+        status_array: np.ndarray = sum(status_arrays)
 
         # Convert to DataFrame so we can index by column name
         statuses = pd.DataFrame(
-            statuses,
+            status_array,
             columns=[
                 "alive",
                 "crc_death",

--- a/crcsim/output.py
+++ b/crcsim/output.py
@@ -137,13 +137,14 @@ class Output:
             {"record_type": "lifespan", "person_id": person_id, "time": time}
         )
 
-    def add_routine_test_chosen(self, person_id: Any, test_name: str):
+    def add_routine_test_chosen(self, person_id: Any, test_name: str, time: float):
         self.rows.append(
             {
                 "record_type": "test_chosen",
                 "person_id": person_id,
                 "test_name": test_name,
                 "role": TestingRole.ROUTINE,
+                "time": time,
             }
         )
 

--- a/crcsim/parameters.py
+++ b/crcsim/parameters.py
@@ -64,4 +64,23 @@ def load_params(file):
                 y=params[f"death_rate_{race}_{sex}_rates"],
             )
 
+    if params["use_variable_routine_test"]:
+        params["variable_routine_test"] = StepFunction(
+            x=params["routine_testing_year"], y=params["routine_test_by_year"]
+        )
+        for test_name, test_params in params["tests"].items():
+            # Indexing 0 and -1 here safely returns the min and max testing years,
+            # because initializing the StepFunction raises an error if the testing
+            # years are not sorted in increasing order.
+            if test_params["routine_start"] != params["routine_testing_year"][0]:
+                raise ValueError(
+                    f"routine_start for {test_name} does not equal the first year"
+                    " of routine testing specified in routine_testing_year."
+                )
+            if test_params["routine_end"] != params["routine_testing_year"][-1]:
+                raise ValueError(
+                    f"routine_start for {test_name} does not equal the last year"
+                    " of routine testing specified in routine_testing_year."
+                )
+
     return params

--- a/parameters.json
+++ b/parameters.json
@@ -106,6 +106,9 @@
   "diagnostic_test": "Colonoscopy",
   "surveillance_test": "Colonoscopy",
   "polypectomy_proportion_lethal": 0.00002,
+  "use_variable_routine_test": true,
+  "routine_testing_year": [           50,            51,            52,            53,            54,            55,            56,            57,            58,            59,            60,    61,    62,    63,    64,    65,    66,    67,    68,    69,    70,    71,    72,    73,    74,    75 ],
+  "routine_test_by_year": ["Colonoscopy", "Colonoscopy", "Colonoscopy", "Colonoscopy", "Colonoscopy", "Colonoscopy", "Colonoscopy", "Colonoscopy", "Colonoscopy", "Colonoscopy", "Colonoscopy", "FIT", "FIT", "FIT", "FIT", "FIT", "FIT", "FIT", "FIT", "FIT", "FIT", "FIT", "FIT", "FIT", "FIT", "FIT" ],
 
   "cost_discount_age": 50,
   "cost_discount_rate": 0.03,

--- a/tests/test_variable_routine_testing.py
+++ b/tests/test_variable_routine_testing.py
@@ -1,7 +1,10 @@
+import json
 import logging
 import pytest
 import random
 from copy import deepcopy
+from pathlib import Path
+from tempfile import TemporaryDirectory
 
 from crcsim.agent import (
     Person,
@@ -9,104 +12,103 @@ from crcsim.agent import (
     PersonTestingMessage,
     PersonTreatmentMessage,
 )
-from crcsim.parameters import load_params
+from crcsim.parameters import load_params, StepFunction
 from crcsim.scheduler import Scheduler
 from crcsim.output import Output
 
 
-class MockScheduler:
-    def __init__(self, time):
-        self.time = time
-
-
 @pytest.fixture(scope="module")
 def params():
+    """
+    Default parameters. Some tests use these as-is; others override some values
+    to test specific scenarios. These are also the current values in parameters.json,
+    but we specify them here so that any future changes to parameters.json don't
+    affect these tests.
+    """
     p = load_params("parameters.json")
 
-    # All test scenarios use FIT and Colonoscopy with testing from age 50 to 75
+    # All test scenarios use FIT and Colonoscopy with testing from age 50 to 75.
     p["routine_testing_year"] = list(range(50, 76))
     p["tests"]["FIT"]["routine_start"] = 50
     p["tests"]["FIT"]["routine_end"] = 75
     p["tests"]["Colonoscopy"]["routine_start"] = 50
     p["tests"]["Colonoscopy"]["routine_end"] = 75
 
-    # Default test switching scenario
-    p["routine_test_by_year"] = ["Colonoscopy"] * 11 + ["FIT"] * 15
+    # All test scenarios use 100% compliance.
+    p["initial_compliance_rate"] = 1.0
+    p["tests"]["FIT"]["compliance_rate_given_prev_compliant"] = [1.0] * 26
+    p["tests"]["Colonoscopy"]["compliance_rate_given_prev_compliant"] = [1.0] * 26
+
+    # We don't want any false positives for these tests, because we rely on each
+    # person completing a normal course of routine testing without any diagnostic
+    # or surveillance testing. In the TestPerson class, we ensure that the person
+    # never has CRC; here we ensure that no routine test returns a false positive
+    # and causes a diagnostic test.
+    p["tests"]["FIT"]["specificity"] = 1
+    p["tests"]["Colonoscopy"]["specificity"] = 1
+
+    # Default test switching scenario. We directly specify variable_routine_test,
+    # which is normally computed from the parameters routine_testing_year and
+    # routine_test_by_year in load_params. We have to specify if directly here
+    # because we've already called load_params, so if we just change
+    # routine_testing_year and routine_test_by_year, variable_routine_test won't
+    # be recomputed, and it is the parameter which ultimately determines test
+    # switching behavior.
+    p["variable_routine_test"] = StepFunction(
+        p["routine_testing_year"], ["Colonoscopy"] * 11 + ["FIT"] * 15
+    )
 
     return p
 
 
-def test_parameter_alignment(params):
-    params_missing_year = deepcopy(params)
-    params_missing_year["routine_testing_year"].pop()
-    with pytest.raises(ValueError):
-        p = Person(
-            id=None,
-            race_ethnicity=None,
-            sex=None,
-            params=params_missing_year,
-            scheduler=Scheduler(),
-            rng=random.Random(1),
-            out=None,
-        )
-        p.start()
-
-    params_missing_test = deepcopy(params)
-    params_missing_test["routine_test_by_year"].pop()
-    with pytest.raises(ValueError):
-        p = Person(
-            id=None,
-            race_ethnicity=None,
-            sex=None,
-            params=params_missing_test,
-            scheduler=Scheduler(),
-            rng=random.Random(1),
-            out=None,
-        )
-        p.start()
-
-    params_unsorted_year = deepcopy(params)
-    params_unsorted_year["routine_testing_year"].reverse()
-    with pytest.raises(ValueError):
-        p = Person(
-            id=None,
-            race_ethnicity=None,
-            sex=None,
-            params=params_unsorted_year,
-            scheduler=Scheduler(),
-            rng=random.Random(1),
-            out=None,
-        )
-        p.start()
-
-    params_wrong_test_end = deepcopy(params)
-    params_wrong_test_end["tests"]["Colonoscopy"]["routine_end"] = 85
-    with pytest.raises(ValueError):
-        p = Person(
-            id=None,
-            race_ethnicity=None,
-            sex=None,
-            params=params_wrong_test_end,
-            scheduler=Scheduler(),
-            rng=random.Random(1),
-            out=None,
-        )
-        p.start()
-
-
 @pytest.fixture(scope="module")
-def test_switching_scenarios():
+def test_switching_scenarios(params):
+    """
+    These test switching scenarios are used to override the default params for some
+    tests.
+    """
+    routine_testing_year = params["routine_testing_year"]
     return {
-        "one_colonoscopy_then_fit_v1": ["Colonoscopy"] + ["FIT"] * 25,
-        "one_colonoscopy_then_fit_v2": ["Colonoscopy"] * 10 + ["FIT"] * 16,
-        "ten_fit_then_colonoscopy": ["FIT"] * 10 + ["Colonoscopy"] * 16,
-        "fit_then_colonoscopy_then_fit": ["FIT"] * 5
-        + ["Colonoscopy"] * 1
-        + ["FIT"] * 20,
+        "one_colonoscopy_then_fit_v1": StepFunction(
+            routine_testing_year, ["Colonoscopy"] + ["FIT"] * 25
+        ),
+        "one_colonoscopy_then_fit_v2": StepFunction(
+            routine_testing_year, ["Colonoscopy"] * 10 + ["FIT"] * 16
+        ),
+        "ten_fit_then_colonoscopy": StepFunction(
+            routine_testing_year, ["FIT"] * 10 + ["Colonoscopy"] * 16
+        ),
+        "fit_then_colonoscopy_then_fit": StepFunction(
+            routine_testing_year, ["FIT"] * 5 + ["Colonoscopy"] * 1 + ["FIT"] * 20
+        ),
     }
 
 
 class TestPerson(Person):
+    """
+    Overrides or adds to the Person class in two ways that are crucial to these tests:
+
+    1. Overrides the start method to ensure that the person never has CRC and lives to
+       100, so they always complete the full course of routine testing.
+    2. Adds a simulate method to simulate one TestPerson at a time without running
+       the main simulation on a cohort of people.
+
+    Also, for convenience, assigns attributes directly in __init__ so we don't have
+    to pass them at instantiation.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.scheduler = Scheduler()
+        self.rng = random.Random(1)
+        # Output class requires a file name, but we don't write to disk in these tests,
+        # so we give it a dummy file name.
+        self.out = Output(file_name="unused")
+        # Sex and race_ethnicity are irrelevant to this test but we need to choose an
+        # arbitrary value for the simulation to run.
+        self.sex = ("female",)
+        self.race_ethnicity = ("black_non_hispanic",)
+
     def start(self):
         self.choose_tests()
 
@@ -139,7 +141,11 @@ class TestPerson(Person):
         # never having a lesion.
 
     def simulate(self):
-        # Simplified version of the simulation loop used in crcsim.__main__
+        """
+        Simplified version of the simulation loop used in crcsim.__main__.
+        Enables us to simulate one TestPerson at a time without running the
+        main simulation on a cohort of people.
+        """
         while not self.scheduler.is_empty():
             event = self.scheduler.consume_next_event()
             if not event.enabled:
@@ -151,51 +157,68 @@ class TestPerson(Person):
             handler(event.message)
 
 
+def test_testing_year_misalignment(params):
+    """
+    Asserts that misaligned testing years in routine_testing_year and a single test's
+    routine start or end raises an error.
+    """
+    with open("parameters.json", "r") as f:
+        params = json.load(f)
+        params["tests"]["Colonoscopy"]["routine_end"] = 85
+        with TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir) / "parameters.json"
+            with open(tmp_path, "w") as f:
+                json.dump(params, f)
+                with pytest.raises(ValueError):
+                    load_params(tmp_path)
+
+
 def test_one_colonoscopy_equivalence(params, test_switching_scenarios):
     """
     Asserts that the one_colonoscopy_then_fit_v1 and one_colonoscopy_then_fit_v2
-    test switching scenarios both result in one colonoscopy and 15 FIT tests for
+    test switching scenarios both result in one colonoscopy and 16 FIT tests for
     a person with 100% compliance. This tests whether the logic in
     crcsim.agent.Person.do_tests, which requires the person to be due for *every*
-    routine test, works in the test switching context.
+    routine test, works in the test switching context. P1 switches to FIT at age
+    51, but they shouldn't get a FIT test until age 60 because they had a
+    colonoscopy at age 50. P2 switches to FIT at age 60, and they should get a FIT
+    test that year.
     """
     params_one_colonoscopy_v1 = deepcopy(params)
-    params_one_colonoscopy_v1["routine_test_by_year"] = test_switching_scenarios[
+    params_one_colonoscopy_v1["variable_routine_test"] = test_switching_scenarios[
         "one_colonoscopy_then_fit_v1"
     ]
 
     params_one_colonoscopy_v2 = deepcopy(params)
-    params_one_colonoscopy_v2["routine_test_by_year"] = test_switching_scenarios[
+    params_one_colonoscopy_v2["variable_routine_test"] = test_switching_scenarios[
         "one_colonoscopy_then_fit_v2"
     ]
 
     p1 = TestPerson(
         id=1,
-        # Sex and race_ethnicity are irrelevant to this test but we need to choose an
-        # arbitrary value for the simulation to run.
-        sex="female",
-        race_ethnicity="black_non_hispanic",
+        sex=None,
+        race_ethnicity=None,
         params=params_one_colonoscopy_v1,
-        scheduler=Scheduler(),
-        rng=random.Random(1),
-        out=Output(),
+        scheduler=None,
+        rng=None,
+        out=None,
     )
     p1.start()
     p1.simulate()
 
     p2 = TestPerson(
         id=2,
-        sex="female",
-        race_ethnicity="black_non_hispanic",
+        sex=None,
+        race_ethnicity=None,
         params=params_one_colonoscopy_v1,
-        scheduler=Scheduler(),
-        rng=random.Random(1),
-        out=Output(),
+        scheduler=None,
+        rng=None,
+        out=None,
     )
     p2.start()
     p2.simulate()
 
-    # Assert that both people have one colonoscopy and 15 FIT tests
+    # Assert that both people have one colonoscopy and 16 FIT tests
     for person in [p1, p2]:
         tests = [
             row for row in person.out.rows if row["record_type"] == "test_performed"
@@ -203,7 +226,7 @@ def test_one_colonoscopy_equivalence(params, test_switching_scenarios):
         colonoscopies = [test for test in tests if test["test_name"] == "Colonoscopy"]
         fits = [test for test in tests if test["test_name"] == "FIT"]
         assert len(colonoscopies) == 1
-        assert len(fits) == 15
+        assert len(fits) == 16
 
 
 def test_ten_fit_then_colonoscopy(params, test_switching_scenarios):
@@ -215,18 +238,18 @@ def test_ten_fit_then_colonoscopy(params, test_switching_scenarios):
     but routine testing ends at age 75.
     """
     params_ten_fit = deepcopy(params)
-    params_ten_fit["routine_test_by_year"] = test_switching_scenarios[
+    params_ten_fit["variable_routine_test"] = test_switching_scenarios[
         "ten_fit_then_colonoscopy"
     ]
 
     p = TestPerson(
         id=None,
-        sex="female",
-        race_ethnicity="black_non_hispanic",
+        sex=None,
+        race_ethnicity=None,
         params=params_ten_fit,
-        scheduler=Scheduler(),
-        rng=random.Random(1),
-        out=Output(),
+        scheduler=None,
+        rng=None,
+        out=None,
     )
     p.start()
     p.simulate()
@@ -241,24 +264,24 @@ def test_ten_fit_then_colonoscopy(params, test_switching_scenarios):
 def test_fit_then_colonoscopy_then_fit(params, test_switching_scenarios):
     """
     Asserts that the fit_then_colonoscopy_then_fit test switching scenario results in
-    five FIT tests, one colonoscopy, then ten FIT tests for a person with 100% compliance.
+    five FIT tests, one colonoscopy, then 11 FIT tests for a person with 100% compliance.
     In this scenario, the person should get a FIT test every year from age 50 to 54, then a
-    colonoscopy at age 55, then a FIT test every year from age 66 to 75 (in total, one
-    colonoscopy and 15 FIT tests).
+    colonoscopy at age 55, then a FIT test every year from age 65 to 75 (in total, one
+    colonoscopy and 16 FIT tests).
     """
     params_fit_then_colonoscopy = deepcopy(params)
-    params_fit_then_colonoscopy["routine_test_by_year"] = test_switching_scenarios[
+    params_fit_then_colonoscopy["variable_routine_test"] = test_switching_scenarios[
         "fit_then_colonoscopy_then_fit"
     ]
 
     p = TestPerson(
         id=None,
-        sex="female",
-        race_ethnicity="black_non_hispanic",
+        sex=None,
+        race_ethnicity=None,
         params=params_fit_then_colonoscopy,
-        scheduler=Scheduler(),
-        rng=random.Random(1),
-        out=Output(),
+        scheduler=None,
+        rng=None,
+        out=None,
     )
     p.start()
     p.simulate()
@@ -267,4 +290,4 @@ def test_fit_then_colonoscopy_then_fit(params, test_switching_scenarios):
     colonoscopies = [test for test in tests if test["test_name"] == "Colonoscopy"]
     fits = [test for test in tests if test["test_name"] == "FIT"]
     assert len(colonoscopies) == 1
-    assert len(fits) == 15
+    assert len(fits) == 16

--- a/tests/test_variable_routine_testing.py
+++ b/tests/test_variable_routine_testing.py
@@ -107,8 +107,8 @@ class TestPerson(Person):
         self.out = Output(file_name="unused")
         # Sex and race_ethnicity are irrelevant to this test but we need to choose an
         # arbitrary value for the simulation to run.
-        self.sex = ("female",)
-        self.race_ethnicity = ("black_non_hispanic",)
+        self.sex = "female"
+        self.race_ethnicity = "black_non_hispanic"
 
     def start(self):
         self.choose_tests()
@@ -166,8 +166,8 @@ def test_testing_year_misalignment(params):
     with open("parameters.json", "r") as f:
         params = json.load(f)
         params["tests"]["Colonoscopy"]["routine_end"] = 85
-        with TemporaryDirectory() as tmpdir:
-            tmp_path = Path(tmpdir) / "parameters.json"
+        with TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir) / "parameters.json"
             with open(tmp_path, "w") as f:
                 json.dump(params, f)
                 with pytest.raises(ValueError):
@@ -196,7 +196,7 @@ def test_one_colonoscopy_equivalence(params, test_switching_scenarios):
     ]
 
     p1 = TestPerson(
-        id=1,
+        id=None,
         sex=None,
         race_ethnicity=None,
         params=params_one_colonoscopy_v1,
@@ -208,7 +208,7 @@ def test_one_colonoscopy_equivalence(params, test_switching_scenarios):
     p1.simulate()
 
     p2 = TestPerson(
-        id=2,
+        id=None,
         sex=None,
         race_ethnicity=None,
         params=params_one_colonoscopy_v1,

--- a/tests/test_variable_routine_testing.py
+++ b/tests/test_variable_routine_testing.py
@@ -1,0 +1,151 @@
+import pytest
+import random
+from copy import deepcopy
+
+from crcsim.agent import Person
+from crcsim.parameters import load_params
+from crcsim.scheduler import Scheduler
+
+
+class MockScheduler:
+    def __init__(self, time):
+        self.time = time
+
+
+@pytest.fixture(scope="module")
+def params():
+    p = load_params("parameters.json")
+
+    # All test scenarios use FIT and Colonoscopy with testing from age 50 to 75
+    p["routine_testing_year"] = list(range(50, 76))
+    p["tests"]["FIT"]["routine_start"] = 50
+    p["tests"]["FIT"]["routine_end"] = 75
+    p["tests"]["Colonoscopy"]["routine_start"] = 50
+    p["tests"]["Colonoscopy"]["routine_end"] = 75
+
+    # Default test switching scenario
+    p["routine_test_by_year"] = ["Colonoscopy"] * 11 + ["FIT"] * 15
+
+    return p
+
+
+def test_parameter_alignment(params):
+    params_missing_year = deepcopy(params)
+    params_missing_year["routine_testing_year"].pop()
+    with pytest.raises(ValueError):
+        p = Person(
+            id=None,
+            race_ethnicity=None,
+            sex=None,
+            params=params_missing_year,
+            scheduler=Scheduler(),
+            rng=random.Random(1),
+            out=None,
+        )
+        p.start()
+
+    params_missing_test = deepcopy(params)
+    params_missing_test["routine_test_by_year"].pop()
+    with pytest.raises(ValueError):
+        p = Person(
+            id=None,
+            race_ethnicity=None,
+            sex=None,
+            params=params_missing_test,
+            scheduler=Scheduler(),
+            rng=random.Random(1),
+            out=None,
+        )
+        p.start()
+
+    params_unsorted_year = deepcopy(params)
+    params_unsorted_year["routine_testing_year"].reverse()
+    with pytest.raises(ValueError):
+        p = Person(
+            id=None,
+            race_ethnicity=None,
+            sex=None,
+            params=params_unsorted_year,
+            scheduler=Scheduler(),
+            rng=random.Random(1),
+            out=None,
+        )
+        p.start()
+
+    params_wrong_test_end = deepcopy(params)
+    params_wrong_test_end["tests"]["Colonoscopy"]["routine_end"] = 85
+    with pytest.raises(ValueError):
+        p = Person(
+            id=None,
+            race_ethnicity=None,
+            sex=None,
+            params=params_wrong_test_end,
+            scheduler=Scheduler(),
+            rng=random.Random(1),
+            out=None,
+        )
+        p.start()
+
+
+@pytest.fixture(scope="module")
+def test_switching_scenarios():
+    return {
+        "one_colonoscopy_then_fit_v1": ["Colonoscopy"] + ["FIT"] * 25,
+        "one_colonoscopy_then_fit_v2": ["Colonoscopy"] * 10 + ["FIT"] * 16,
+        "ten_fit_then_colonoscopy": ["FIT"] * 10 + ["Colonoscopy"] * 16,
+        "fit_then_colonoscopy_then_fit": ["FIT"] * 5
+        + ["Colonoscopy"] * 1
+        + ["FIT"] * 20,
+    }
+
+
+def test_one_colonoscopy_equivalence(params, test_switching_scenarios):
+    """
+    Asserts that the one_colonoscopy_then_fit_v1 and one_colonoscopy_then_fit_v2
+    test switching scenarios both result in one colonoscopy and 15 FIT tests for
+    a person with 100% compliance. This tests whether the logic in
+    crcsim.agent.Person.do_tests, which requires the person to be due for *every*
+    routine test, works in the test switching context.
+    """
+    params_one_colonoscopy_v1 = deepcopy(params)
+    params_one_colonoscopy_v1["routine_test_by_year"] = test_switching_scenarios[
+        "one_colonoscopy_then_fit_v1"
+    ]
+
+    params_one_colonoscopy_v2 = deepcopy(params)
+    params_one_colonoscopy_v2["routine_test_by_year"] = test_switching_scenarios[
+        "one_colonoscopy_then_fit_v2"
+    ]
+
+    ...
+
+
+def test_ten_fit_then_colonoscopy(params, test_switching_scenarios):
+    """
+    Asserts that the ten_fit_then_colonoscopy test switching scenario results in
+    ten FIT tests and two colonoscopies for a person with 100% compliance. In this
+    scenario, the person should get a FIT test every year from age 50 to 59, then a
+    colonoscopy at age 60 and 70. They will be due for a third colonoscopy at age 80,
+    but routine testing ends at age 75.
+    """
+    params_ten_fit = deepcopy(params)
+    params_ten_fit["routine_test_by_year"] = test_switching_scenarios[
+        "ten_fit_then_colonoscopy"
+    ]
+
+    ...
+
+
+def test_fit_then_colonoscopy_then_fit(params, test_switching_scenarios):
+    """
+    Asserts that the fit_then_colonoscopy_then_fit test switching scenario results in
+    five FIT tests, one colonoscopy, then ten FIT tests for a person with 100% compliance.
+    In this scenario, the person should get a FIT test every year from age 50 to 54, then a
+    colonoscopy at age 55, then a FIT test every year from age 56 to 75.
+    """
+    params_fit_then_colonoscopy = deepcopy(params)
+    params_fit_then_colonoscopy["routine_test_by_year"] = test_switching_scenarios[
+        "fit_then_colonoscopy_then_fit"
+    ]
+
+    ...

--- a/tests/test_variable_routine_testing.py
+++ b/tests/test_variable_routine_testing.py
@@ -1,10 +1,11 @@
 import json
 import logging
-import pytest
 import random
 from copy import deepcopy
 from pathlib import Path
 from tempfile import TemporaryDirectory
+
+import pytest
 
 from crcsim.agent import (
     Person,
@@ -12,9 +13,9 @@ from crcsim.agent import (
     PersonTestingMessage,
     PersonTreatmentMessage,
 )
-from crcsim.parameters import load_params, StepFunction
-from crcsim.scheduler import Scheduler
 from crcsim.output import Output
+from crcsim.parameters import StepFunction, load_params
+from crcsim.scheduler import Scheduler
 
 
 @pytest.fixture(scope="module")
@@ -290,4 +291,5 @@ def test_fit_then_colonoscopy_then_fit(params, test_switching_scenarios):
     colonoscopies = [test for test in tests if test["test_name"] == "Colonoscopy"]
     fits = [test for test in tests if test["test_name"] == "FIT"]
     assert len(colonoscopies) == 1
+    assert len(fits) == 16
     assert len(fits) == 16


### PR DESCRIPTION
Prior to this PR, the routine test used by each person is assigned at the start of their lifespan based on the `proportion` parameters for each test. They use the same routine test throughout their lifespan.

The goal of this PR is to enable us to simulate scenarios where a person uses multiple different routine tests throughout their lifespan. This is accomplished by specifying a single pattern of routine test availability that each person in the simulation uses. For example, in the default scenario in `parameters.json`, everyone in the simulation has colonoscopy as their routine test from age 50 to 60 and FIT as their routine test from age 61 to 75. 

A tradeoff of this approach is that we lose the ability to probabilistically vary the routine test assigned to people within the simulation. Everyone in the simulation uses the same test-year pattern. Because we may still want to use the old test assignment functionality, a boolean parameter `use_variable_routine_test` determines whether the test pattern parameters are used.