### PR TITLE
Draw expected lifespans at start of simulation for consistency

### DIFF
--- a/crcsim/__main__.py
+++ b/crcsim/__main__.py
@@ -98,7 +98,7 @@ def run(
     out.open()
 
     with open(cohort_file, mode="r") as input:
-        cohort = csv.DictReader(input)
+        cohort = list(csv.DictReader(input))
 
         # Draw expected lifespans for everyone in the cohort prior to starting
         # simulations. This is necessary to ensure that expected lifespans are

--- a/crcsim/__main__.py
+++ b/crcsim/__main__.py
@@ -10,6 +10,75 @@ from crcsim.parameters import load_params
 from crcsim.scheduler import Scheduler
 
 
+def compute_lifespan(rng: random.Random, params: dict, cohort_row: dict) -> float:
+    """
+    Return a randomly-computed lifespan based on the death rate parameters.
+    """
+
+    rand = rng.random()
+    cum_prob_survive = 1.0
+    cum_prob_death = 0.0
+    sex = Sex(cohort_row["sex"])
+    race_ethnicity = RaceEthnicity(cohort_row["race_ethnicity"])
+
+    # Find the appropriate death rate table. We don't have separate tables
+    # for all combinations of sex and race_ethnicity, so we'll need to do
+    # some imperfect combining of categories.
+    if sex == Sex.FEMALE:
+        if race_ethnicity == RaceEthnicity.WHITE_NON_HISPANIC:
+            death_rate = params["death_rate_white_female"]
+        elif race_ethnicity in (
+            RaceEthnicity.HISPANIC,
+            RaceEthnicity.BLACK_NON_HISPANIC,
+            RaceEthnicity.OTHER_NON_HISPANIC,
+        ):
+            death_rate = params["death_rate_black_female"]
+        else:
+            raise ValueError(f"Unexpected race/ethnicity value: {race_ethnicity}")
+    elif sex in (Sex.MALE, Sex.OTHER):
+        if race_ethnicity == RaceEthnicity.WHITE_NON_HISPANIC:
+            death_rate = params["death_rate_white_male"]
+        elif race_ethnicity in (
+            RaceEthnicity.HISPANIC,
+            RaceEthnicity.BLACK_NON_HISPANIC,
+            RaceEthnicity.OTHER_NON_HISPANIC,
+        ):
+            death_rate = params["death_rate_black_male"]
+        else:
+            raise ValueError(f"Unexpected race/ethnicity value: {race_ethnicity}")
+    else:
+        raise ValueError(f"Unexpected sex value: {sex}")
+
+    # Move through the death table, searching for the age at which the
+    # person's cumulative probability of death exceeds the random number we
+    # generated. This is the age when the person will die.
+    found_lifespan = False
+
+    for i in range(params["max_age"] + 1):
+        cond_prob_death = death_rate(i)
+        prob_death = cond_prob_death * cum_prob_survive
+        cum_prob_death += prob_death
+        cum_prob_survive *= 1 - cond_prob_death
+        if rand < cum_prob_death:
+            # Calculate the lifespan as the current year plus the fraction that
+            # the random number slips into the next year.
+            lifespan = i + 1 - ((cum_prob_death - rand) / prob_death)
+            found_lifespan = True
+            break
+
+    # If we went through the death table without finding a lifespan (this
+    # can happen if the max age is less than the upper bound of the death
+    # table, for example), set the lifespan to the max age.
+    if not found_lifespan:
+        lifespan = params["max_age"]
+
+    # Just in case, cap the lifespan at the max age.
+    if lifespan > params["max_age"]:
+        lifespan = params["max_age"]
+
+    return lifespan
+
+
 def run(
     seed=None,
     npeople=None,
@@ -30,6 +99,16 @@ def run(
 
     with open(cohort_file, mode="r") as input:
         cohort = csv.DictReader(input)
+
+        # Draw expected lifespans for everyone in the cohort prior to starting
+        # simulations. This is necessary to ensure that expected lifespans are
+        # always the same for a given seed. If we drew lifespans during the cohort
+        # loop, the state of the random number generator at the time of drawing each
+        # lifespan would be affected by the number of draws that occurred while
+        # simulating the previous persons, which is affected by parameters other
+        # than the seed.
+        expected_lifespans = [compute_lifespan(rng, params, p) for p in cohort]
+
         for i, p in enumerate(cohort):
             if npeople is not None and i >= npeople:
                 break
@@ -40,6 +119,7 @@ def run(
                 id=p["id"],
                 sex=Sex(p["sex"]),
                 race_ethnicity=RaceEthnicity(p["race_ethnicity"]),
+                expected_lifespan=expected_lifespans[i],
                 params=params,
                 scheduler=scheduler,
                 rng=rng,

--- a/crcsim/agent.py
+++ b/crcsim/agent.py
@@ -997,7 +997,6 @@ class Person:
     # on_end_year is just a wrapper for update_value - not necessary as far as I can tell
 
     def start_life_timer(self):
-        self.expected_lifespan = self.compute_lifespan()
         self.scheduler.add_event(
             message=PersonDiseaseMessage.OTHER_DEATH,
             handler=self.handle_disease_message,

--- a/crcsim/agent.py
+++ b/crcsim/agent.py
@@ -163,16 +163,17 @@ class Sex(Enum):
 
 
 class Person:
-    def __init__(self, id, sex, race_ethnicity, params, scheduler, rng, out):
+    def __init__(
+        self, id, sex, race_ethnicity, expected_lifespan, params, scheduler, rng, out
+    ):
         self.id = id
         self.sex = sex
         self.race_ethnicity = race_ethnicity
+        self.expected_lifespan = expected_lifespan
         self.params = params
         self.scheduler = scheduler
         self.rng = rng
         self.out = out
-
-        self.expected_lifespan = None
 
         self.lesions = []
         self.lesion_risk_index = None
@@ -994,76 +995,6 @@ class Person:
             return fp
 
     # on_end_year is just a wrapper for update_value - not necessary as far as I can tell
-
-    def compute_lifespan(self) -> float:
-        """
-        Return a randomly-computed lifespan based on the death rate parameters.
-        """
-
-        rand = self.rng.random()
-        cum_prob_survive = 1.0
-        cum_prob_death = 0.0
-
-        # Find the appropriate death rate table. We don't have separate tables
-        # for all combinations of sex and race_ethnicity, so we'll need to do
-        # some imperfect combining of categories.
-        if self.sex == Sex.FEMALE:
-            if self.race_ethnicity == RaceEthnicity.WHITE_NON_HISPANIC:
-                death_rate = self.params["death_rate_white_female"]
-            elif self.race_ethnicity in (
-                RaceEthnicity.HISPANIC,
-                RaceEthnicity.BLACK_NON_HISPANIC,
-                RaceEthnicity.OTHER_NON_HISPANIC,
-            ):
-                death_rate = self.params["death_rate_black_female"]
-            else:
-                raise ValueError(
-                    f"Unexpected race/ethnicity value: {self.race_ethnicity}"
-                )
-        elif self.sex in (Sex.MALE, Sex.OTHER):
-            if self.race_ethnicity == RaceEthnicity.WHITE_NON_HISPANIC:
-                death_rate = self.params["death_rate_white_male"]
-            elif self.race_ethnicity in (
-                RaceEthnicity.HISPANIC,
-                RaceEthnicity.BLACK_NON_HISPANIC,
-                RaceEthnicity.OTHER_NON_HISPANIC,
-            ):
-                death_rate = self.params["death_rate_black_male"]
-            else:
-                raise ValueError(
-                    f"Unexpected race/ethnicity value: {self.race_ethnicity}"
-                )
-        else:
-            raise ValueError(f"Unexpected sex value: {self.sex}")
-
-        # Move through the death table, searching for the age at which the
-        # person's cumulative probability of death exceeds the random number we
-        # generated. This is the age when the person will die.
-        found_lifespan = False
-
-        for i in range(self.params["max_age"] + 1):
-            cond_prob_death = death_rate(i)
-            prob_death = cond_prob_death * cum_prob_survive
-            cum_prob_death += prob_death
-            cum_prob_survive *= 1 - cond_prob_death
-            if rand < cum_prob_death:
-                # Calculate the lifespan as the current year plus the fraction that
-                # the random number slips into the next year.
-                lifespan = i + 1 - ((cum_prob_death - rand) / prob_death)
-                found_lifespan = True
-                break
-
-        # If we went through the death table without finding a lifespan (this
-        # can happen if the max age is less than the upper bound of the death
-        # table, for example), set the lifespan to the max age.
-        if not found_lifespan:
-            lifespan = self.params["max_age"]
-
-        # Just in case, cap the lifespan at the max age.
-        if lifespan > self.params["max_age"]:
-            lifespan = self.params["max_age"]
-
-        return lifespan
 
     def start_life_timer(self):
         self.expected_lifespan = self.compute_lifespan()

--- a/crcsim/analysis.py
+++ b/crcsim/analysis.py
@@ -970,11 +970,11 @@ class Analysis:
         """
         # Sum all of the person status arrays to get an array of counts of the number of
         # people in each status for each year.
-        statuses: np.ndarray = sum(status_arrays)
+        status_array: np.ndarray = sum(status_arrays)
 
         # Convert to DataFrame so we can index by column name
         statuses = pd.DataFrame(
-            statuses,
+            status_array,
             columns=[
                 "alive",
                 "crc_death",


### PR DESCRIPTION
In some recent experiments, we want to quantify life years saved as `mean_lifespan_implementation` - `mean_lifespan_baseline`. Other than initial compliance rate, the baseline and implementation scenarios use the same parameters. For a given iteration, which uses the same seed, we want life expectancy to be exactly the same, but it’s not.

This is due to the way we use the random number generator. We simulate each person one at a time, and we may need to draw a different number of random numbers for each person depending on the other parameters. So by the time we get to the next person’s life expectancy draw, the random number generator can be in a different state.

These random differences are fairly large, relative to the effect sizes of the initial compliance rate differences. This throws off the life years saved calculation.

This PR implements a fix by drawing expected lifespans at the start of the simulation.

In draft for now, because this still needs to be tested with an experiment.